### PR TITLE
feat: Improve formatting and add the packages as click.choices

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -1,8 +1,8 @@
 Goal of this project
 ====================
 
-The goal is to be able to track the differences between Ubuntu packaging of google-guest-agent and the upstream
-packaging of google-guest-agent.
+The goal is to be able to track the differences between Ubuntu packaging of the 4 guest-agents, and the upstream
+packaging of said agents.
 
 We need to be able to annotate/exclude some of these differences to that if the differences change we can report and alert.
 
@@ -11,48 +11,93 @@ Usage
 
 .. code-block:: bash
 
-    wget --output-document=upstream-control "https://raw.githubusercontent.com/GoogleCloudPlatform/guest-agent/main/packaging/debian/control"
-    wget --output-document=ubuntu-control "https://git.launchpad.net/ubuntu/+source/google-guest-agent/plain/debian/control?h=applied/ubuntu/noble-devel"
-    python3 google_guest_agent_packaging_diff_tool.py --upstream-control-file ./upstream-control --ubuntu-control-file ./ubuntu-control
+    python3 google_guest_agent_packaging_diff_tool.py --agent-package google-osconfig-agent
+
+The current output is as follows:
+
+.. code-block:: bash
+
+    $ python3 google_guest_agent_packaging_diff_tool.py --agent-package google-guest-agent
+
+    ############## Comparing "Build-Depends" ##############
+    "Build-Depends" field in Google upstream:
+     debhelper (>= 9.20160709), dh-golang (>= 1.1), golang-go
+    [   [   {   'name': 'debhelper',
+                'archqual': None,
+                'version': ('>=', '9.20160709'),
+                'arch': None,
+                'restrictions': None}],
+        [   {   'name': 'dh-golang',
+                'archqual': None,
+                'version': ('>=', '1.1'),
+                'arch': None,
+                'restrictions': None}],
+        [   {   'name': 'golang-go',
+                'archqual': None,
+                'version': None,
+                'arch': None,
+                'restrictions': None}]]
+    ------------
+    "Build-Depends" field in ubuntu:
+     debhelper-compat (= 12),
+                   dh-golang,
+                   golang-any
+    [   [   {   'name': 'debhelper-compat',
+                'archqual': None,
+                'version': ('=', '12'),
+                'arch': None,
+                'restrictions': None}],
+        [   {   'name': 'dh-golang',
+                'archqual': None,
+                'version': None,
+                'arch': None,
+                'restrictions': None}],
+        [   {   'name': 'golang-any',
+                'archqual': None,
+                'version': None,
+                'arch': None,
+                'restrictions': None}]]
+
+    ############## Comparing "Depends" ##############
+    "Depends" field in Google upstream:
+     ${misc:Depends}, google-compute-engine-oslogin (>= 1:20231003)
+    "Depends" field in ubuntu:
+     ${misc:Depends},
+             ${shlibs:Depends},
+             google-compute-engine-oslogin (>= 20231004.00-0ubuntu1)
+
+    ############## Comparing "Breaks" ##############
+    "Breaks" field not present in Google Upstream
+    ------------
+    "Breaks" field in ubuntu:
+     gce-compute-image-packages (<< 20191115),
+            python3-google-compute-engine
+    [   [   {   'name': 'gce-compute-image-packages',
+                'archqual': None,
+                'version': ('<<', '20191115'),
+                'arch': None,
+                'restrictions': None}],
+        [   {   'name': 'python3-google-compute-engine',
+                'archqual': None,
+                'version': None,
+                'arch': None,
+                'restrictions': None}]]
+
+    ############## Comparing "Replaces" ##############
+    "Replaces" field not present in Google Upstream
+    ------------
+    "Replaces" field in ubuntu:
+     gce-compute-image-packages (<< 20191115)
+    [   [   {   'name': 'gce-compute-image-packages',
+                'archqual': None,
+                'version': ('<<', '20191115'),
+                'arch': None,
+                'restrictions': None}]]
 
 TODO
 ----
 
-This project is very much in progress and is currently in POC stage. The following are the things that need to be done:
+As we do more and more SRUs independently, we should:
 
-* Currently the differences are printed to stdout. We need to add a way to annotate the differences so that we can track them.
-* Add support for other debian packaging file diffs too - not just control file.
-* Report on annotated differences as well as unannotated differences.
-* Exit 1 if there are differences that are not annotated/expected.
-
-The current output is as follow:
-
-.. code-block:: bash
-
-    ❯ python3 google_guest_agent_packaging_diff_tool.py --upstream-control-file ./upstream-control --ubuntu-control-file ./ubuntu-control
-    Build-Depends
-    [[{'name': 'debhelper', 'archqual': None, 'version': ('>=', '9.20160709'), 'arch': None, 'restrictions': None}], [{'name': 'dh-golang', 'archqual': None, 'version': ('>=', '1.1'), 'arch': None, 'restrictions': None}], [{'name': 'golang-go', 'archqual': None, 'version': None, 'arch': None, 'restrictions': None}]]
-            upstream: debhelper ('>=', '9.20160709')
-            upstream: dh-golang ('>=', '1.1')
-            upstream: golang-go None
-    [[{'name': 'debhelper-compat', 'archqual': None, 'version': ('=', '12'), 'arch': None, 'restrictions': None}], [{'name': 'dh-golang', 'archqual': None, 'version': None, 'arch': None, 'restrictions': None}], [{'name': 'golang-any', 'archqual': None, 'version': None, 'arch': None, 'restrictions': None}]]
-            ubuntu: debhelper-compat ('=', '12')
-            ubuntu: dh-golang None
-            ubuntu: golang-any None
-    Depends
-    cannot parse package relationship "${misc:Depends}", returning it raw
-    [[{'name': '${misc:Depends}', 'archqual': None, 'version': None, 'arch': None, 'restrictions': None}], [{'name': 'google-compute-engine-oslogin', 'archqual': None, 'version': ('>=', '1:20231003'), 'arch': None, 'restrictions': None}]]
-            upstream: ${misc:Depends} None
-            upstream: google-compute-engine-oslogin ('>=', '1:20231003')
-    cannot parse package relationship "${misc:Depends}", returning it raw
-    cannot parse package relationship "${shlibs:Depends}", returning it raw
-    [[{'name': '${misc:Depends}', 'archqual': None, 'version': None, 'arch': None, 'restrictions': None}], [{'name': '${shlibs:Depends}', 'archqual': None, 'version': None, 'arch': None, 'restrictions': None}], [{'name': 'google-compute-engine-oslogin', 'archqual': None, 'version': ('>=', '20231004.00-0ubuntu1'), 'arch': None, 'restrictions': None}]]
-            ubuntu: ${misc:Depends} None
-            ubuntu: ${shlibs:Depends} None
-            ubuntu: google-compute-engine-oslogin ('>=', '20231004.00-0ubuntu1')
-    Breaks
-            upstream: None
-            ubuntu: None
-    Replaces
-            upstream: None
-            ubuntu: None
+* Create a benchmark for "acceptable" diffs
+* Once we have a benchmark, `exit 1` if there are diffs beyond that and warn

--- a/google_guest_agent_packaging_diff_tool.py
+++ b/google_guest_agent_packaging_diff_tool.py
@@ -84,31 +84,34 @@ def main(agent_package: str) -> None:
     upstream_control_fields = parse_control_file(GOOGLE_CONTROL_FILENAME)
 
     # Compare the control fields
-    for field_name in [field_to_compare for field_to_compare in ubuntu_control_fields.keys() if field_to_compare in FIELDS_TO_COMPARE]:
-        with warnings.catch_warnings():
-            warnings.filterwarnings("error")
-            print(f"\n############## Comparing \"{field_name}\" ##############")
-            if field_name in upstream_control_fields.keys():
-                print(f"\"{field_name}\" field in Google upstream:\n {upstream_control_fields[field_name]}")
-                try:
-                    upstream_relations = deb822.PkgRelation.parse_relations(upstream_control_fields[field_name])
-                    pprint.pprint(upstream_relations, indent=4, sort_dicts=False)
-                    print("------------")
-                except Warning:
-                    pass
-            else:
-                print(f"\"{field_name}\" field not present in Google Upstream\n------------")
-            if field_name in ubuntu_control_fields.keys():
-                print(f"\"{field_name}\" field in ubuntu:\n {ubuntu_control_fields[field_name]}")
-                try:
-                    ubuntu_relations = deb822.PkgRelation.parse_relations(ubuntu_control_fields[field_name])
-                    pprint.pprint(ubuntu_relations, indent=4, sort_dicts=False)
-                except Warning:
-                    pass
-            else:
-                print(f"\"{field_name}\" field not present in ubuntu")
-
-    clean_up()
+    try:
+        for field_name in [field_to_compare for field_to_compare in ubuntu_control_fields.keys() if field_to_compare in FIELDS_TO_COMPARE]:
+            with warnings.catch_warnings():
+                warnings.filterwarnings("error")
+                print(f"\n############## Comparing \"{field_name}\" ##############")
+                if field_name in upstream_control_fields.keys():
+                    print(f"\"{field_name}\" field in Google upstream:\n {upstream_control_fields[field_name]}")
+                    try:
+                        upstream_relations = deb822.PkgRelation.parse_relations(upstream_control_fields[field_name])
+                        pprint.pprint(upstream_relations, indent=4, sort_dicts=False)
+                        print("------------")
+                    except Warning:
+                        pass
+                else:
+                    print(f"\"{field_name}\" field not present in Google Upstream\n------------")
+                if field_name in ubuntu_control_fields.keys():
+                    print(f"\"{field_name}\" field in ubuntu:\n {ubuntu_control_fields[field_name]}")
+                    try:
+                        ubuntu_relations = deb822.PkgRelation.parse_relations(ubuntu_control_fields[field_name])
+                        pprint.pprint(ubuntu_relations, indent=4, sort_dicts=False)
+                    except Warning:
+                        pass
+                else:
+                    print(f"\"{field_name}\" field not present in ubuntu")
+    except Exception as err:
+        sys.exit(f"The following error occurred: {err}")
+    finally:
+        clean_up()
 
 
 if __name__ == '__main__':

--- a/google_guest_agent_packaging_diff_tool.py
+++ b/google_guest_agent_packaging_diff_tool.py
@@ -1,46 +1,114 @@
-from pprint import pprint
 import os
 import click
-from debian import deb822
+import pprint
+import requests
+import sys
+import warnings
 
-def parse_control_file(control_file):
-    control_file_text = control_file.read()
+from dataclasses import dataclass
+from debian import deb822
+from debian.deb822 import Deb822
+
+UBUNTU_CONTROL_FILENAME = "ubuntu_control.file"
+GOOGLE_CONTROL_FILENAME = "gce_control.file"
+
+FIELDS_TO_COMPARE = ["Build-Depends", "Depends", "Recommends",
+                     "Suggests", "Breaks", 'Conflicts',
+                     'Replaces', 'Provides']
+
+@dataclass
+class ArchiveURLS:
+    ubuntu_control_url: str
+    google_upstream_control_url: str
+
+archives: dict[str, ArchiveURLS]
+
+archive_dict = {
+    "gce-compute-image-packages": [
+        "https://git.launchpad.net/~ubuntu-core-dev/+git/gce-compute-image-packages/plain/debian/control?h=ubuntu/master",
+        "https://raw.githubusercontent.com/GoogleCloudPlatform/guest-configs/master/packaging/debian/control"
+    ],
+    "google-compute-engine-oslogin": [
+        "https://git.launchpad.net/~ubuntu-core-dev/+git/google-compute-engine-oslogin/plain/debian/control?h=ubuntu/master",
+        "https://raw.githubusercontent.com/GoogleCloudPlatform/guest-oslogin/master/packaging/debian/control"
+    ],
+    "google-guest-agent": [
+        "https://git.launchpad.net/~ubuntu-core-dev/+git/google-guest-agent/plain/debian/control?h=ubuntu/master",
+        "https://raw.githubusercontent.com/GoogleCloudPlatform/guest-agent/main/packaging/debian/control"
+    ],
+    "google-osconfig-agent": [
+        "https://git.launchpad.net/~ubuntu-core-dev/+git/google-osconfig-agent/plain/debian/control?h=ubuntu/master",
+        "https://raw.githubusercontent.com/GoogleCloudPlatform/osconfig/master/packaging/debian/control"
+    ],
+} # type: archives
+
+def clean_up() -> None:
+    os.remove(UBUNTU_CONTROL_FILENAME)
+    os.remove(GOOGLE_CONTROL_FILENAME)
+
+def parse_control_file(control_file: str | os.PathLike) -> Deb822:
+    with open(control_file) as fp:
+        control_file_text = fp.read()
+
     control_file_text_no_blank_lines = os.linesep.join([s for s in control_file_text.splitlines() if s])
-    control_fileds = deb822.Deb822(control_file_text_no_blank_lines)
+    control_fileds = Deb822(control_file_text_no_blank_lines)
     return control_fileds
 
-
 @click.command()
-@click.option('--upstream-control-file', type=click.File(), required=True, help='Upstream control files to compare')
-@click.option('--ubuntu-control-file', type=click.File(), required=True, help='Ubuntu control files to compare')
-def main(upstream_control_file, ubuntu_control_file):
-    # wget --output-document=ubuntu-control "https://git.launchpad.net/ubuntu/+source/google-guest-agent/tree/debian/control?h=applied/ubuntu/noble-devel"
-    # wget --output-document=ubuntu-control "https://git.launchpad.net/ubuntu/+source/google-guest-agent/plain/debian/control?h=applied/ubuntu/noble-devel"
-    ubuntu_control_fields = parse_control_file(ubuntu_control_file)
-    upstream_control_fields = parse_control_file(upstream_control_file)
-    fields_to_compare = ['Build-Depends', 'Depends', 'Recommends', 'Suggests', 'Breaks', 'Conflicts', 'Replaces', 'Provides']
+@click.option('--agent-package', required=True,
+              type=click.Choice(["gce-compute-image-packages",
+                                        "google-compute-engine-oslogin",
+                                        "google-guest-agent",
+                                        "google-osconfig-agent"], case_sensitive=False),
+              help='The package to inspect')
 
-    # compare the above control fields
-    for field_name in [field_to_compare for field_to_compare in ubuntu_control_fields.keys() if field_to_compare in fields_to_compare]:
-        print(f'{field_name}')
-        if field_name in upstream_control_fields.keys():
-            # print(f'\tupstream: {upstream_control_fields[field_name]}')
-            relations = deb822.PkgRelation.parse_relations(upstream_control_fields[field_name])
-            print(relations)
-            for relation in relations:
-                for relation_item in relation:
-                    print(f'\tupstream: {relation_item["name"]} {relation_item["version"]}')
-        else:
-            print(f'\tupstream: None')
-        if field_name in upstream_control_fields.keys():
-            # print(f'\tubuntu: {ubuntu_control_fields[field_name]}')
-            relations = deb822.PkgRelation.parse_relations(ubuntu_control_fields[field_name])
-            print(relations)
-            for relation in relations:
-                for relation_item in relation:
-                    print(f'\tubuntu: {relation_item["name"]} {relation_item["version"]}')
-        else:
-            print(f'\tubuntu: None')
+def main(agent_package: str) -> None:
+
+    url_list = archive_dict[agent_package]
+
+    ubuntu_req = requests.get(url_list[0])
+    if ubuntu_req.ok:
+        with open(UBUNTU_CONTROL_FILENAME, "w+") as fp:
+            fp.write(ubuntu_req.text)
+    else:
+        sys.exit(f"Error {ubuntu_req.status_code} - is {url_list[0]} still available?")
+
+    google_req = requests.get(url_list[1])
+    if google_req.ok:
+        with open(GOOGLE_CONTROL_FILENAME, "w+") as fp:
+            fp.write(google_req.text)
+    else:
+        sys.exit(f"Error {google_req.status_code} - is {url_list[1]} still available?")
+
+    ubuntu_control_fields = parse_control_file(UBUNTU_CONTROL_FILENAME)
+    upstream_control_fields = parse_control_file(GOOGLE_CONTROL_FILENAME)
+
+    # Compare the control fields
+    for field_name in [field_to_compare for field_to_compare in ubuntu_control_fields.keys() if field_to_compare in FIELDS_TO_COMPARE]:
+        with warnings.catch_warnings():
+            warnings.filterwarnings("error")
+            print(f"\n############## Comparing \"{field_name}\" ##############")
+            if field_name in upstream_control_fields.keys():
+                print(f"\"{field_name}\" field in Google upstream:\n {upstream_control_fields[field_name]}")
+                try:
+                    upstream_relations = deb822.PkgRelation.parse_relations(upstream_control_fields[field_name])
+                    pprint.pprint(upstream_relations, indent=4, sort_dicts=False)
+                    print("------------")
+                except Warning:
+                    pass
+            else:
+                print(f"\"{field_name}\" field not present in Google Upstream\n------------")
+            if field_name in ubuntu_control_fields.keys():
+                print(f"\"{field_name}\" field in ubuntu:\n {ubuntu_control_fields[field_name]}")
+                try:
+                    ubuntu_relations = deb822.PkgRelation.parse_relations(ubuntu_control_fields[field_name])
+                    pprint.pprint(ubuntu_relations, indent=4, sort_dicts=False)
+                except Warning:
+                    pass
+            else:
+                print(f"\"{field_name}\" field not present in ubuntu")
+
+    clean_up()
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
Previously the d/control files for both ubuntu and Google (upstream) had
to be passed in as variables for diff-ing; now one can pass the pkg name
in and it'll automatically grab the d/control files.
  
Also edited the formatting for readability (used pprint, suppress irrelevant warnings from debian.deb822, etc.) and updated the README.rst to reflect changes
